### PR TITLE
fix(string): rename String#b as String#bold

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,13 +179,13 @@ Method         | Description
 fg(fg)         | Set text to be printed with the foreground color `fg` (example: `"TEST".fg(84)`)
 bg(bg)         | Set text to be printed with the background color `bg` (example: `"TEST".bg("dd32a9")`)
 fb(fg, bg)     | Set text to be printed with the foreground color `fg` and background color `bg` (example: `"TEST".fb(84,196)`)
-b              | Set text to be printed in bold (example: `"TEST".b`)
+bold           | Set text to be printed in bold (example: `"TEST".bold`)
 i              | Set text to be printed in italic (example: `"TEST".i`)
 u              | Set text to be printed underlined (example: `"TEST".u`)
 l              | Set text to be printed blinking (example: `"TEST".l`)
 r              | Set text to be printed in reverse colors (example: `"TEST".r`)
 c(code)        | Use coded format like "TEST".c("204,45,bui") to print "TEST" in bold, underline italic, fg=204 and bg=45 (the format is `.c("fg,bg,biulr")`)
-pure           | Strip text of any "dressing" (example: with `text = "TEST".b`, you will have bold text in the variable `text`, then with `text.pure` it will show "uncoded" or pure text)
+pure           | Strip text of any "dressing" (example: with `text = "TEST".bold`, you will have bold text in the variable `text`, then with `text.pure` it will show "uncoded" or pure text)
 clean_ansi     | Strip seemingly uncolored strings of ansi code (those that are enclosed in "\e[0m"
 shorten(n)     | Shorten the pure version of the string to 'n' characters, preserving any ANSI coding
 inject("chars",pos) | Inject "chars" at position 'pos' in the pure version of the string (if 'pos' is '-1', then append at end). Preserves any ANSI code
@@ -416,10 +416,9 @@ end
 **Problem:** `wait_readable` method not found.  
 **Solution:** Always include `require 'io/wait'` for stdin flush.
 
-### 5. `String#b` Overrides Ruby's Built-in Binary Method
-**Problem:** rcurses defines `String#b` for bold formatting, but Ruby's built-in `String#b` returns a binary-encoded copy of the string. Any code using `''.b` or `str.b` for binary I/O will silently get ANSI bold codes instead.
-**Impact:** Binary protocol parsers, socket readers, and encoding-sensitive code will break when rcurses is loaded.
-**Workaround:** Use `String.new(encoding: 'ASCII-8BIT')` instead of `''.b` when you need binary strings in code that coexists with rcurses.
+### 5. `String#bold` Avoids Ruby's Built-in Binary Method
+**Problem:** Ruby already defines `String#b` to return a binary-encoded copy of the string. Reusing that method name for bold formatting causes conflicts in encoding-sensitive code.
+**Resolution:** rcurses uses `String#bold` for bold formatting, leaving Ruby's built-in `String#b` untouched.
 
 ### 6. Border Changes Not Visible
 **Problem:** Changing pane border property doesn't show visual changes.  
@@ -450,7 +449,7 @@ require 'rcurses'
 @max_h, @max_w = IO.console.winsize
 mypane = Rcurses::Pane.new(@max_w/2, 30, 30, 10, 19, 229)
 mypane.border = true
-mypane.text = "Hello".i + " World!".b.i + "\n \n" + "rcurses".r + " " + "is cool".c("16,212")
+mypane.text = "Hello".i + " World!".bold.i + "\n \n" + "rcurses".r + " " + "is cool".c("16,212")
 mypane.refresh
 mypane.edit
 ```

--- a/examples/basic_panes.rb
+++ b/examples/basic_panes.rb
@@ -14,10 +14,10 @@ pane_right  = Rcurses::Pane.new(@max_w/2 + 1,      2,     @max_w/2, @max_h - 2, 
 pane_left.border     = true # Adding a border to the left pane
 
 # Add content to the panes
-pane_top.text        = Time.now.to_s[0..15].b + "   Welcome to the rcurses example program"
+pane_top.text        = Time.now.to_s[0..15].bold + "   Welcome to the rcurses example program"
 pane_left.text       = `ls --color`
 pane_right.text      = "Output of free:\n\n" + `free`
-pane_bottom.prompt   = "Enter any text and press ENTER: ".b # The prompt text before the user starts writing content
+pane_bottom.prompt   = "Enter any text and press ENTER: ".bold # The prompt text before the user starts writing content
 
 pane_top.refresh     # This is the order of drawing/refreshing the panes
 pane_left.refresh    # ...then the left pane

--- a/lib/rcurses/emoji.rb
+++ b/lib/rcurses/emoji.rb
@@ -197,13 +197,13 @@ module Rcurses
                 tab_rows << []
                 row_w = 0
               end
-              tab_rows.last << (i == cat_idx ? tab.b.r : tab)
+              tab_rows.last << (i == cat_idx ? tab.bold.r : tab)
               row_w += tw
             end
             tab_rows.each { |tr| lines << tr.join("") }
             header_lines = tab_rows.size
           else
-            lines << " Search: #{search}".b
+            lines << " Search: #{search}".bold
             header_lines = 1
           end
           lines << ""

--- a/lib/rcurses/pane.rb
+++ b/lib/rcurses/pane.rb
@@ -477,7 +477,7 @@ module Rcurses
     end
 
     def parse(cont)
-      cont.gsub!(/\*(.+?)\*/, '\1'.b)
+      cont.gsub!(/\*(.+?)\*/, '\1'.bold)
       cont.gsub!(/\/(.+?)\//, '\1'.i)
       cont.gsub!(/_(.+?)_/, '\1'.u)
       cont.gsub!(/#(.+?)#/, '\1'.r)
@@ -954,4 +954,3 @@ module Rcurses
     end
   end
 end
-

--- a/lib/string_extensions.rb
+++ b/lib/string_extensions.rb
@@ -45,7 +45,7 @@ class String
   end
 
   # bold, italic, underline, blink, reverse
-  def b; color(self, "\e[1m",   "\e[22m"); end
+  def bold; color(self, "\e[1m",   "\e[22m"); end
   def i; color(self, "\e[3m",   "\e[23m"); end
   def u; color(self, "\e[4m",   "\e[24m"); end
   def l; color(self, "\e[5m",   "\e[25m"); end
@@ -208,4 +208,3 @@ class String
     has_ansi? ? self : bg(color)
   end
 end
-

--- a/test/test_string_extensions.rb
+++ b/test/test_string_extensions.rb
@@ -43,7 +43,7 @@ class TestStringExtensions < Minitest::Test
   end
 
   def test_bold
-    result = "hi".b
+    result = "hi".bold
     assert_includes result, "\e[1m"
     assert_includes result, "hi"
     assert_includes result, "\e[22m"


### PR DESCRIPTION
 ## About

 I ran into a strange bug yesterday where when I required rcurses,
 the requests I made with net/http would start to fail because of
 incorrect chunk sizes.

 After spending time debugging it, I discovered that rcurses has
 a monkey of String#b that changes its behavior, and I also discovered
 that Net::HTTP uses String#b when `read_body` is being used, and maybe
 in other places.

  The monkeypatch appears to have been the problem, as after I renamed
 it to String#bold instead, the problem disappeared.

 ## Changes

 * Rename String#b to String#bold.